### PR TITLE
Fix action permissions

### DIFF
--- a/.github/workflows/mistake_check.yml
+++ b/.github/workflows/mistake_check.yml
@@ -10,6 +10,9 @@ jobs:
   getfiles:
     name: Check changed files for mistakes
     runs-on: ubuntu-latest
+    
+    permissions:
+      pull-requests: write
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
The action was giving an error 403 when attempting to comment on PRs previously; this fixes that.