### PR TITLE
Update rus.po

### DIFF
--- a/translations/rus.po
+++ b/translations/rus.po
@@ -1003,7 +1003,7 @@ msgstr "Синхронизация успешна."
 
 #: ../client/application/game/ui/screens/accounts/screen_synchronize.cpp:62
 msgid "All your medals are here."
-msgstr "Все медали сохранены."
+msgstr "Все медали зачислены."
 
 #: ../client/application/game/ui/screens/accounts/screen_signed_out.cpp:16
 msgid "Account"


### PR DESCRIPTION
Change "All your medals are here" (EN): from "All medals saved" to "All medals added." (RU) This is a mistake I made 2 years ago back when I assumed syncing is *sending* medals to the server rather than retrieving them from it. As a side note: "All your medals are here" is not immediately understandable (all my medals are *where*?)